### PR TITLE
feat: implement Battles global store

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,12 +20,25 @@ import LogInRedirect from "./pages/LogInRedirect/LogInRedirect";
 import NavFooter from "./components/NavFooter/NavFooter";
 import { useArmiesStore } from "./store/armies";
 import { useEffect } from "react";
+import { useBattlesStore } from "./store/battles";
 
 function App() {
   const { armies, fetchAllArmies } = useArmiesStore();
+  const {
+    upcomingBattles,
+    completedBattles,
+    fetchUpcomingBattles,
+    fetchCompletedBattles,
+  } = useBattlesStore();
   useEffect(() => {
     if (!armies[0]) {
       fetchAllArmies();
+    }
+    if (!upcomingBattles[0]) {
+      fetchUpcomingBattles();
+    }
+    if (!completedBattles[0]) {
+      fetchCompletedBattles;
     }
   });
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
       fetchUpcomingBattles();
     }
     if (!completedBattles[0]) {
-      fetchCompletedBattles;
+      fetchCompletedBattles();
     }
   });
   return (

--- a/src/components/CompletedBattles/CompletedBattles.tsx
+++ b/src/components/CompletedBattles/CompletedBattles.tsx
@@ -1,45 +1,25 @@
-import { useEffect, useState } from "react";
-import { getCompletedBattlesFive } from "../../utils/BattleRequests";
+import { useState } from "react";
 import { CompletedBattle } from "../../utils/Interfaces";
 import DateTableHeader from "../DateTableHeader/DateTableHeader";
 import "./CompletedBattles.scss";
 import { Link } from "react-router-dom";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { CircularProgress } from "@mui/material";
 import NewBattleCompleteTableRow from "../NewBattleTableCompleteRow copy/NewBattleCompleteTableRow";
-
-interface CompletedBattleArray extends Array<CompletedBattle> {}
+import { useBattlesStore } from "../../store/battles";
 
 export default function CompletedBattles() {
-  const [battleArray, setBattleArray] = useState<CompletedBattleArray>();
   const [hideSectionBool, setHideSectionBool] = useState<boolean>(false);
 
+  const { completedBattles } = useBattlesStore();
+
   let currentDate = "";
-
-  useEffect(() => {
-    const battleFn = async () => {
-      const data = await getCompletedBattlesFive();
-      setBattleArray(data);
-      return data;
-    };
-
-    battleFn();
-  }, []);
 
   const handleClick = () => {
     hideSectionBool === false
       ? setHideSectionBool(true)
       : setHideSectionBool(false);
   };
-
-  if (!battleArray) {
-    return (
-      <div className="loading-message">
-        <CircularProgress style={{ color: "white" }} />
-      </div>
-    );
-  }
 
   return (
     <section className="completedbattles">
@@ -64,8 +44,8 @@ export default function CompletedBattles() {
           hideSectionBool === false ? "completedbattles-list" : "section--hide"
         }
       >
-        {battleArray.map((battle: CompletedBattle, index: number) => {
-          if (index > 5) {
+        {completedBattles.map((battle: CompletedBattle, index: number) => {
+          if (index > 4) {
             return;
           }
           if (index === 0) {

--- a/src/components/NewBattleTableRow/NewBattleTableRow.tsx
+++ b/src/components/NewBattleTableRow/NewBattleTableRow.tsx
@@ -30,7 +30,7 @@ export default function NewBattleTableRow({
         <div className="new-battle-table-row__combatant-wrap">
           {player_1.map((player: Player) => (
             <NewBattleCard
-              key={player.id}
+              key={player.army_id}
               player={player}
               player_number={"one"}
             />
@@ -46,7 +46,7 @@ export default function NewBattleTableRow({
         <div className="new-battle-table-row__combatant-wrap">
           {player_2.map((player) => (
             <NewBattleCard
-              key={player.id}
+              key={player.army_id}
               player={player}
               player_number={"two"}
             />

--- a/src/components/UpcomingBattles/UpcomingBattles.tsx
+++ b/src/components/UpcomingBattles/UpcomingBattles.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { getUpcomingBattlesFive } from "../../utils/BattleRequests";
+import { useState } from "react";
 import "./UpcomingBattles.scss";
 import DateTableHeader from "../DateTableHeader/DateTableHeader";
 import { Player } from "../../utils/Interfaces";
@@ -8,6 +7,7 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { CircularProgress } from "@mui/material";
 import NewBattleTableRow from "../NewBattleTableRow/NewBattleTableRow";
+import { useBattlesStore } from "../../store/battles";
 
 interface Battle {
   id: string;
@@ -21,23 +21,12 @@ interface Battle {
   finish: string;
 }
 
-interface BattleArray extends Array<Battle> {}
-
 export default function UpcomingBattles() {
-  const [battleArray, setBattleArray] = useState<BattleArray>();
   const [hideSectionBool, setHideSectionBool] = useState<boolean>(false);
 
+  const { upcomingBattles } = useBattlesStore();
+
   let currentDate = "";
-
-  useEffect(() => {
-    const battleFn = async () => {
-      const data = await getUpcomingBattlesFive();
-      setBattleArray(data);
-      return data;
-    };
-
-    battleFn();
-  }, []);
 
   const handleClick = () => {
     hideSectionBool === false
@@ -45,7 +34,7 @@ export default function UpcomingBattles() {
       : setHideSectionBool(false);
   };
 
-  if (!battleArray) {
+  if (!upcomingBattles) {
     return (
       <div className="loading-message">
         <CircularProgress style={{ color: "white" }} />
@@ -78,8 +67,8 @@ export default function UpcomingBattles() {
             : "section--hide"
         }
       >
-        {battleArray.map((battle: Battle, index: number) => {
-          if (index > 5) {
+        {upcomingBattles.map((battle: Battle, index: number) => {
+          if (index > 4) {
             return;
           }
           if (index === 0) {

--- a/src/pages/CompletedBattlesPage/CompletedBattlesPage.tsx
+++ b/src/pages/CompletedBattlesPage/CompletedBattlesPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { getCompletedBattles } from "../../utils/BattleRequests";
 import "./CompletedBattlesPage.scss";
 import { CompletedBattle } from "../../utils/Interfaces";
 import DateTableHeader from "../../components/DateTableHeader/DateTableHeader";
@@ -10,13 +9,15 @@ import logo from "../../assets/logo.svg";
 import dayjs from "dayjs";
 import NewBattleCompleteTableRow from "../../components/NewBattleTableCompleteRow copy/NewBattleCompleteTableRow";
 import { CircularProgress } from "@mui/material";
+import { useBattlesStore } from "../../store/battles";
 
 interface BattleArray extends Array<CompletedBattle> {}
 interface NameArray extends Array<string> {}
 interface yearArray extends Array<number> {}
 
 export default function CompletedBattlesPage() {
-  const [battleArray, setBattleArray] = useState<BattleArray>();
+  const { completedBattles } = useBattlesStore();
+  const [battleArray, setBattleArray] = useState<BattleArray>(completedBattles);
   const [nameArray, setNameArray] = useState<NameArray>();
   const [yearArray, setYearArray] = useState<yearArray>();
   const [nameFilter, setNameFilter] = useState<string>("all");
@@ -25,16 +26,6 @@ export default function CompletedBattlesPage() {
   const [battleTypeFilter, setBattleTypeFilter] = useState<string>("all");
 
   let currentDate = "";
-
-  useEffect(() => {
-    const battleFn = async () => {
-      const data = await getCompletedBattles();
-      setBattleArray(data);
-      return data;
-    };
-
-    battleFn();
-  }, []);
 
   useEffect(() => {
     const nameFn = async () => {
@@ -63,18 +54,17 @@ export default function CompletedBattlesPage() {
   useEffect(() => {
     let tempBattleArray: BattleArray = [];
     const filterFn = async () => {
-      const data = await getCompletedBattles();
-      tempBattleArray = await data;
+      tempBattleArray = completedBattles;
       let filterArray: Array<CompletedBattle> = [];
 
       if (nameFilter !== "Name" && nameFilter !== "all") {
         filterArray = tempBattleArray?.filter((battle) => {
-          let playerOneArray = battle.player_1.map((player) => {
+          const playerOneArray = battle.player_1.map((player) => {
             if (player.known_as === nameFilter) {
               return true;
             }
           });
-          let playerTwoArray = battle.player_2.map((player) => {
+          const playerTwoArray = battle.player_2.map((player) => {
             if (player.known_as === nameFilter) {
               return true;
             }
@@ -128,7 +118,7 @@ export default function CompletedBattlesPage() {
         filterArray[0] &&
         battleTypeFilter !== "all"
       ) {
-        let battleFilterArray = filterArray?.filter(
+        const battleFilterArray = filterArray?.filter(
           (battle: CompletedBattle) => battle.battle_type === battleTypeFilter
         );
 
@@ -153,7 +143,7 @@ export default function CompletedBattlesPage() {
       } else setBattleArray(tempBattleArray);
     };
     filterFn();
-  }, [nameFilter, battleTypeFilter, yearFilter, monthFilter]);
+  }, [nameFilter, battleTypeFilter, yearFilter, monthFilter, completedBattles]);
 
   const handleChange = (event: any) => {
     if (event.target.name === "battle-type") {

--- a/src/pages/CompletedBattlesPage/CompletedBattlesPage.tsx
+++ b/src/pages/CompletedBattlesPage/CompletedBattlesPage.tsx
@@ -13,13 +13,14 @@ import { useBattlesStore } from "../../store/battles";
 
 interface BattleArray extends Array<CompletedBattle> {}
 interface NameArray extends Array<string> {}
-interface yearArray extends Array<number> {}
+interface YearArray extends Array<number> {}
 
 export default function CompletedBattlesPage() {
   const { completedBattles } = useBattlesStore();
-  const [battleArray, setBattleArray] = useState<BattleArray>(completedBattles);
+  const [battleArray, setBattleArray] =
+    useState<CompletedBattle[]>(completedBattles);
   const [nameArray, setNameArray] = useState<NameArray>();
-  const [yearArray, setYearArray] = useState<yearArray>();
+  const [yearArray, setYearArray] = useState<YearArray>();
   const [nameFilter, setNameFilter] = useState<string>("all");
   const [yearFilter, setYearFilter] = useState<string>("all");
   const [monthFilter, setMonthFilter] = useState<string>("all");
@@ -34,7 +35,7 @@ export default function CompletedBattlesPage() {
       return data;
     };
     nameFn();
-    let dateArray: yearArray = [];
+    let dateArray: YearArray = [];
     if (battleArray !== undefined) {
       dateArray = battleArray?.map((battle) => {
         if (dateArray.includes(dayjs(battle.date).year())) {

--- a/src/pages/UpcomingBattlesPage/UpcomingBattlesPage.tsx
+++ b/src/pages/UpcomingBattlesPage/UpcomingBattlesPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { getUpcomingBattles } from "../../utils/BattleRequests";
 import "./UpcomingBattlesPage.scss";
 import { Battle } from "../../utils/Interfaces";
 import DateTableHeader from "../../components/DateTableHeader/DateTableHeader";
@@ -9,28 +8,21 @@ import { getAllUsersNames } from "../../utils/UserRequests";
 import logo from "../../assets/logo.svg";
 import NewBattleTableRow from "../../components/NewBattleTableRow/NewBattleTableRow";
 import { CircularProgress } from "@mui/material";
+import { useBattlesStore } from "../../store/battles";
 
 interface BattleArray extends Array<Battle> {}
 interface NameArray extends Array<string> {}
 
 export default function UpcomingBattlesPage() {
-  const [battleArray, setBattleArray] = useState<BattleArray>();
+  const { upcomingBattles } = useBattlesStore();
+
+  const [battleArray, setBattleArray] = useState<BattleArray>(upcomingBattles);
   const [nameArray, setNameArray] = useState<NameArray>();
   const [nameFilter, setNameFilter] = useState<string>("Name");
   const [battleTypeFilter, setBattleTypeFilter] =
     useState<string>("Battle Type");
 
   let currentDate = "";
-
-  useEffect(() => {
-    const battleFn = async () => {
-      const data = await getUpcomingBattles(3);
-      setBattleArray(data);
-      return data;
-    };
-
-    battleFn();
-  }, []);
 
   useEffect(() => {
     const nameFn = async () => {
@@ -44,17 +36,16 @@ export default function UpcomingBattlesPage() {
   useEffect(() => {
     let tempBattleArray: BattleArray = [];
     const filterFn = async () => {
-      const data = await getUpcomingBattles(3);
-      tempBattleArray = await data;
+      tempBattleArray = upcomingBattles;
       let filterArray: any = [];
       if (nameFilter !== "Name" && nameFilter !== "all") {
         filterArray = tempBattleArray?.filter((battle) => {
-          let playerOneArray = battle.player_1.map((player) => {
+          const playerOneArray = battle.player_1.map((player) => {
             if (player.known_as === nameFilter) {
               return true;
             }
           });
-          let playerTwoArray = battle.player_2.map((player) => {
+          const playerTwoArray = battle.player_2.map((player) => {
             if (player.known_as === nameFilter) {
               return true;
             }
@@ -71,7 +62,7 @@ export default function UpcomingBattlesPage() {
         filterArray[0] &&
         battleTypeFilter !== "all"
       ) {
-        let battleFilterArray = filterArray?.filter(
+        const battleFilterArray = filterArray?.filter(
           (battle: any) => battle.battle_type === battleTypeFilter
         );
 

--- a/src/pages/UserDashboard/UserDashboard.tsx
+++ b/src/pages/UserDashboard/UserDashboard.tsx
@@ -13,15 +13,13 @@ import { CircularProgress } from "@mui/material";
 import { useArmiesStore } from "../../store/armies";
 import { useBattlesStore } from "../../store/battles";
 
-interface RankArray extends Array<Rank> {}
-
-interface AllRankArray {
-  fortyK: RankArray;
-  fantasy: RankArray;
+interface AllRanks {
+  fortyK: Rank[];
+  fantasy: Rank[];
 }
 
 export default function UserDashboard() {
-  const [rankArray, setRankArray] = useState<AllRankArray>();
+  const [rankArray, setRankArray] = useState<AllRanks>();
   const [userResults, setUserResults] = useState();
   const [ally, setAlly] = useState<Rank | undefined>();
   const [nemesis, setNemesis] = useState<Rank | undefined>();
@@ -30,7 +28,6 @@ export default function UserDashboard() {
   const token = sessionStorage.getItem("token");
   const { fetchUserArmies } = useArmiesStore();
   const { fetchUserBattles, userBattles } = useBattlesStore();
-  console.log(userBattles);
 
   const navigate = useNavigate();
 

--- a/src/store/battles.tsx
+++ b/src/store/battles.tsx
@@ -11,7 +11,7 @@ import {
 interface BattlesState {
   upcomingBattles: Battle[];
   completedBattles: CompletedBattle[];
-  userBattles: { battleArray: Battle[]; userResults: CompletedBattle[] };
+  userBattles: { battleArray: Battle[]; userResults: CompletedBattle[] } | null;
   selectedBattle: Battle | null;
 
   fetchUpcomingBattles: () => Promise<void>;
@@ -26,7 +26,7 @@ export const useBattlesStore = create<BattlesState>()(
     (set) => ({
       upcomingBattles: [],
       completedBattles: [],
-      userBattles: { battleArray: [], userResults: [] },
+      userBattles: null,
       selectedBattle: null,
 
       fetchUpcomingBattles: async () => {

--- a/src/store/battles.tsx
+++ b/src/store/battles.tsx
@@ -14,7 +14,6 @@ interface BattlesState {
   userBattles: { battleArray: Battle[]; userResults: CompletedBattle[] };
   selectedBattle: Battle | null;
 
-  // Actions
   fetchUpcomingBattles: () => Promise<void>;
   fetchCompletedBattles: () => Promise<void>;
   fetchUserBattles: (token: string) => Promise<void>;
@@ -33,6 +32,7 @@ export const useBattlesStore = create<BattlesState>()(
       fetchUpcomingBattles: async () => {
         try {
           const battles = await getUpcomingBattles(3);
+          console.log("store", battles);
           set({ upcomingBattles: battles });
         } catch (error) {
           console.error(error);

--- a/src/store/battles.tsx
+++ b/src/store/battles.tsx
@@ -5,19 +5,16 @@ import {
   getUpcomingBattles,
   getCompletedBattles,
   getUsersBattles,
-  getOneBattle,
 } from "../utils/BattleRequests";
 
 interface BattlesState {
   upcomingBattles: Battle[];
   completedBattles: CompletedBattle[];
   userBattles: { battleArray: Battle[]; userResults: CompletedBattle[] } | null;
-  selectedBattle: Battle | null;
 
   fetchUpcomingBattles: () => Promise<void>;
   fetchCompletedBattles: () => Promise<void>;
   fetchUserBattles: (token: string) => Promise<void>;
-  fetchBattleDetails: (battleId: string) => Promise<void>;
   clearBattles: () => void;
 }
 
@@ -56,21 +53,11 @@ export const useBattlesStore = create<BattlesState>()(
         }
       },
 
-      fetchBattleDetails: async (battleId: string) => {
-        try {
-          const battle = await getOneBattle(battleId);
-          set({ selectedBattle: battle });
-        } catch (error) {
-          console.error(error);
-        }
-      },
-
       clearBattles: () => {
         set({
           upcomingBattles: [],
           completedBattles: [],
           userBattles: { battleArray: [], userResults: [] },
-          selectedBattle: null,
         });
       },
     }),
@@ -80,7 +67,6 @@ export const useBattlesStore = create<BattlesState>()(
         upcomingBattles: state.upcomingBattles,
         completedBattles: state.completedBattles,
         userBattles: state.userBattles,
-        selectedBattle: state.selectedBattle,
       }),
     }
   )

--- a/src/store/battles.tsx
+++ b/src/store/battles.tsx
@@ -32,7 +32,6 @@ export const useBattlesStore = create<BattlesState>()(
       fetchUpcomingBattles: async () => {
         try {
           const battles = await getUpcomingBattles(3);
-          console.log("store", battles);
           set({ upcomingBattles: battles });
         } catch (error) {
           console.error(error);


### PR DESCRIPTION
## What does this PR do?

This PR covers the battle request part of the global store, updating the relevant functions and locations where things like `upcoming battles` and `completed battled` are used.

I decided to delete the `battleDetails` stuff cause it is only used once and is quite specific to the Battle Info page